### PR TITLE
Fixes _toHtml method of Checkout/Block/Cart/Link class

### DIFF
--- a/app/code/Magento/Checkout/Block/Cart/Link.php
+++ b/app/code/Magento/Checkout/Block/Cart/Link.php
@@ -65,7 +65,7 @@ class Link extends \Magento\Framework\View\Element\Html\Link
      */
     protected function _toHtml()
     {
-        if ($this->_moduleManager->isOutputEnabled('Magento_Checkout')) {
+        if (!$this->_moduleManager->isOutputEnabled('Magento_Checkout')) {
             return '';
         }
         return parent::_toHtml();


### PR DESCRIPTION
Related issue: https://github.com/magento/magento2/issues/3821